### PR TITLE
Fix Playwright test fail in todo-nodejs-mongo

### DIFF
--- a/tests/todo.spec.ts
+++ b/tests/todo.spec.ts
@@ -3,25 +3,29 @@ import { v4 as uuidv4 } from "uuid";
 
 test("Create and delete item test", async ({ page }) => {
   await page.goto("/");
+  
+  await new Promise<void>(resolve => setTimeout(() => resolve(), 5000)).then(async () => {
 
-  await expect(page.locator("text=My List").first()).toBeVisible({
-    timeout: 240 * 1000,
+    await expect(page.locator("text=My List").first()).toBeVisible({
+      timeout: 240 * 1000,
+    });
+  
+    await expect(page.locator("text=This list is empty.").first()).toBeVisible()
+  
+    const guid = uuidv4();
+    console.log(`Creating item with text: ${guid}`);
+  
+    await page.locator('[placeholder="Add an item"]').focus();
+    await page.locator('[placeholder="Add an item"]').type(guid);
+    await page.locator('[placeholder="Add an item"]').press("Enter");
+  
+    console.log(`Deleting item with text: ${guid}`);
+    await expect(page.locator(`text=${guid}`).first()).toBeVisible()
+  
+    await page.locator(`text=${guid}`).click();
+    await page.locator('button[role="menuitem"]:has-text("Delete")').click();
+  
+    await expect(page.locator(`text=${guid}`).first()).toBeHidden()
+
   });
-
-  await expect(page.locator("text=This list is empty.").first()).toBeVisible()
-
-  const guid = uuidv4();
-  console.log(`Creating item with text: ${guid}`);
-
-  await page.locator('[placeholder="Add an item"]').focus();
-  await page.locator('[placeholder="Add an item"]').type(guid);
-  await page.locator('[placeholder="Add an item"]').press("Enter");
-
-  console.log(`Deleting item with text: ${guid}`);
-  await expect(page.locator(`text=${guid}`).first()).toBeVisible()
-
-  await page.locator(`text=${guid}`).click();
-  await page.locator('button[role="menuitem"]:has-text("Delete")').click();
-
-  await expect(page.locator(`text=${guid}`).first()).toBeHidden()
 });


### PR DESCRIPTION
Fixes issue [246](https://github.com/Azure/azure-dev/issues/246)

Change files: tests/todo.spec.ts
Add `setTimeOut` is used to wait for the page data to full load.

@rajeshkamal5050 for notification.